### PR TITLE
Add "workflow_states" parameter on autocomplete widget...

### DIFF
--- a/collective/datagridcolumns/ReferenceColumn.py
+++ b/collective/datagridcolumns/ReferenceColumn.py
@@ -17,7 +17,8 @@ class ReferenceColumn(Column):
     security = ClassSecurityInfo()
 
     def __init__(self, label, col_description=None, default=None, default_method=None,
-                required=False, object_provides=[], surf_site=True, search_site=True):
+                required=False, object_provides=[], workflow_states=[], surf_site=True,
+                search_site=True):
         if required or col_description:
             # sorry for this trick, but we are using this product with a custom DataGridField 1.6.4
             # see https://github.com/RedTurtle/Products.DataGridField/tree/1.6
@@ -26,6 +27,7 @@ class ReferenceColumn(Column):
         else:
             Column.__init__(self, label, default=default, default_method=default_method)
         self.object_provides = object_provides
+        self.workflow_states = workflow_states
         self.surf_site = surf_site
         self.search_site = search_site
 
@@ -53,6 +55,12 @@ class ReferenceColumn(Column):
     def getAllowedInterfaces(self):
         """ Return the a proper comma separated strings of object_provides values """
         return ','.join(self.object_provides)
+
+    security.declarePublic('getAllowedStates')
+
+    def getAllowedStates(self):
+        """ Return the a proper comma separated strings of workflow_states values """
+        return ','.join(self.workflow_states)
 
     security.declarePublic('surfSite')
 

--- a/collective/datagridcolumns/browser/autocomplete.py
+++ b/collective/datagridcolumns/browser/autocomplete.py
@@ -11,15 +11,15 @@ except ImportError:
 
 class DataGridAutocompleteView(BrowserView):
     """Return a search on the site for referenced objects
-    
+
     It commonly return a JSON with results
-    
+
     The view need a "term" parameter
-    
+
     An optional "origin" parameter can give to the view the traversal path of the calling context
-    
+
     """
-    
+
     def __call__(self, *args, **kw):
         context = self.context
         request = self.request
@@ -34,7 +34,8 @@ class DataGridAutocompleteView(BrowserView):
         object_provides = request.get('object_provides')
         search_site = request.get('search_site')
         surf_site = request.get('surf_site')
-        
+        workflow_states = request.get('workflow_states')
+
         # PATH search
         if term.startswith('/') and surf_site:
             portal = getToolByName(context, 'portal_url').getPortalObject()
@@ -58,6 +59,8 @@ class DataGridAutocompleteView(BrowserView):
                       'path': path}
             if object_provides:
                 kwargs['object_provides'] = object_provides
+            if workflow_states:
+                kwargs['review_state'] = workflow_states
             try:
                 results = catalog(**kwargs)
                 return json.dumps([{'label': x.Title,
@@ -66,4 +69,4 @@ class DataGridAutocompleteView(BrowserView):
             except ParseError:
                 pass
         return json.dumps([])
-        
+

--- a/collective/datagridcolumns/skins/collective.datagridcolumns/datagrid_reference_cell.pt
+++ b/collective/datagridcolumns/skins/collective.datagridcolumns/datagrid_reference_cell.pt
@@ -25,6 +25,7 @@
         <span style="display:none" class="edit_common"
                      tal:attributes="data-context-call python:column_definition.getAJAXCallingContext(context);
                              data-object-provides column_definition/getAllowedInterfaces;
+                             data-workflow-states column_definition/getAllowedStates;
                              data-surf-site python:column_definition.surfSite() and 'true' or '';
                              data-search-site python:column_definition.searchSite() and 'true' or '';">
         </span>

--- a/collective/datagridcolumns/skins/collective.datagridcolumns/datagridautocomplete.js
+++ b/collective/datagridcolumns/skins/collective.datagridcolumns/datagridautocomplete.js
@@ -32,6 +32,14 @@
 					}
 				}
 
+				var workflow_states = configuration.attr('data-workflow-states');
+				if (workflow_states) {
+					workflow_states = workflow_states.split(',');
+					for (i = 0; i < workflow_states.length; i++) {
+						query.push('workflow_states:list=' + workflow_states[i]);
+					}
+				}
+
 				var search_site = configuration.attr('data-search-site');
 				var surf_site = configuration.attr('data-surf-site');
 				if (search_site) {

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 - Display the selected values in the MultiSelectColumn view macro
   instead of displaying a special char ("V")
   [gbastien]
+- ReferenceColumn - Add ``workflow_states``  parameter
+  [sdelcourt]
 
 
 0.6.2 (2014-02-19)


### PR DESCRIPTION
.. so listed objects can be filtered by workflow states (exactly the same behaviour as "object_provides" parameter but with a list of string allowed states instead).

Thank you for reviewing and merging ;-)

Simon
